### PR TITLE
Support token-exchange after id_token received

### DIFF
--- a/cmd/openid-client.go
+++ b/cmd/openid-client.go
@@ -59,6 +59,8 @@ func main() {
 			"      -port             Callback port. Open on localhost a port to retrieve the authorization code. Optional parameter, default: 8080\n" +
 			"      -username         User name for command password grant required, else optional.\n" +
 			"      -password         User password for command password grant required, else optional.\n" +
+			"      -requested_type   Token-Exchange requested type.\n" +
+			"      -provider_name    Provider name for token-exchange.\n" +
 			"      -h                Show this help for more details.")
 	}
 
@@ -82,6 +84,8 @@ func main() {
 	var userPassword = flag.String("password", "", "User password for command password grant required, else optional")
 	var appTid = flag.String("app_tid", "", "Application tenant ID")
 	var command = flag.String("cmd", "", "Single command to be executed")
+	var requestedType = flag.String("requested_type", "", "Token-Exchange requested type")
+	var providerName = flag.String("provider_name", "", "Provider name for token-exchange")
 	var mTLS bool = false
 	var privateKeyJwt string = ""
 	if len(os.Args) > 1 && strings.HasPrefix(os.Args[1], "-") == false {
@@ -306,6 +310,18 @@ func main() {
 			data, _ := json.MarshalIndent(idpTokenResponse, "", "    ")
 			fmt.Println("Response from endpoint /exchange/corporateidp")
 			fmt.Println(string(data))
+		}
+		if *requestedType != "" && idToken != "" {
+			requestMap.Set("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange")
+			requestMap.Set("subject_token_type", "urn:ietf:params:oauth:token-type:id_token")
+			requestMap.Set("subject_token", idToken)
+			requestMap.Set("requested_token_type", "urn:ietf:params:oauth:token-type:"+*requestedType)
+			if *providerName != "" {
+				requestMap.Set("resource", "urn:sap:identity:application:provider:name:"+*providerName)
+			}
+			var exchangedTokenResponse = client.HandleTokenExchangeGrant(requestMap, *provider, *tlsClient, verbose)
+			fmt.Println("Response from token-exchange endpoint ")
+			fmt.Println(exchangedTokenResponse)
 		}
 	}
 }

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -385,6 +385,40 @@ func HandlePasswordGrant(request url.Values, provider oidc.Provider, tlsClient h
 	return refreshToken
 }
 
+func HandleTokenExchangeGrant(request url.Values, provider oidc.Provider, tlsClient http.Client, verbose bool) string {
+	accessToken := ""
+	request.Set("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange")
+	req, requestError := http.NewRequest("POST", provider.Endpoint().TokenURL, strings.NewReader(request.Encode()))
+	if requestError != nil {
+		log.Fatal(requestError)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+	resp, clientError := tlsClient.Do(req)
+	if clientError != nil {
+		log.Fatal(clientError)
+	}
+	var result map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&result)
+	if result != nil {
+		jsonStr, marshalError := json.Marshal(result)
+		if marshalError != nil {
+			log.Fatal(marshalError)
+		}
+		var myToken oauth2.Token
+		json.Unmarshal([]byte(jsonStr), &myToken)
+		if myToken.AccessToken == "" {
+			fmt.Println(string(jsonStr))
+		} else {
+			if verbose {
+				fmt.Println("Access Token: " + myToken.AccessToken)
+			}
+			accessToken = myToken.AccessToken
+		}
+	}
+	return accessToken
+}
+
 func CreatePrivateKeyJwt(clientID string, x509Cert x509.Certificate, tokenEndpoint string, privateKey crypto.PrivateKey) (string, error) {
 	certSum := sha1.Sum(x509Cert.Raw)
 	sha1Sum := base64.RawURLEncoding.EncodeToString(certSum[:])

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -385,40 +385,6 @@ func HandlePasswordGrant(request url.Values, provider oidc.Provider, tlsClient h
 	return refreshToken
 }
 
-func HandleTokenExchangeGrant(request url.Values, provider oidc.Provider, tlsClient http.Client, verbose bool) string {
-	accessToken := ""
-	request.Set("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange")
-	req, requestError := http.NewRequest("POST", provider.Endpoint().TokenURL, strings.NewReader(request.Encode()))
-	if requestError != nil {
-		log.Fatal(requestError)
-	}
-	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
-	req.Header.Set("Accept", "application/json")
-	resp, clientError := tlsClient.Do(req)
-	if clientError != nil {
-		log.Fatal(clientError)
-	}
-	var result map[string]interface{}
-	json.NewDecoder(resp.Body).Decode(&result)
-	if result != nil {
-		jsonStr, marshalError := json.Marshal(result)
-		if marshalError != nil {
-			log.Fatal(marshalError)
-		}
-		var myToken oauth2.Token
-		json.Unmarshal([]byte(jsonStr), &myToken)
-		if myToken.AccessToken == "" {
-			fmt.Println(string(jsonStr))
-		} else {
-			if verbose {
-				fmt.Println("Access Token: " + myToken.AccessToken)
-			}
-			accessToken = myToken.AccessToken
-		}
-	}
-	return accessToken
-}
-
 func CreatePrivateKeyJwt(clientID string, x509Cert x509.Certificate, tokenEndpoint string, privateKey crypto.PrivateKey) (string, error) {
 	certSum := sha1.Sum(x509Cert.Raw)
 	sha1Sum := base64.RawURLEncoding.EncodeToString(certSum[:])

--- a/pkg/client/exchange.go
+++ b/pkg/client/exchange.go
@@ -56,3 +56,48 @@ func HandleCorpIdpExchangeFlow(clientID string, clientSecret string, existingIdT
 	}
 	return outBodyMap
 }
+
+func HandleTokenExchangeGrant(request url.Values, provider oidc.Provider, tlsClient http.Client, verbose bool) string {
+	accessToken := ""
+	request.Set("grant_type", "urn:ietf:params:oauth:grant-type:token-exchange")
+	req, requestError := http.NewRequest("POST", provider.Endpoint().TokenURL, strings.NewReader(request.Encode()))
+	if requestError != nil {
+		log.Fatal(requestError)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+	resp, clientError := tlsClient.Do(req)
+	if clientError != nil {
+		log.Fatal(clientError)
+	}
+	var result map[string]interface{}
+	json.NewDecoder(resp.Body).Decode(&result)
+	if result != nil {
+		jsonStr, marshalError := json.Marshal(result)
+		if marshalError != nil {
+			log.Fatal(marshalError)
+		}
+		var myToken oauth2.Token
+		json.Unmarshal([]byte(jsonStr), &myToken)
+		if myToken.AccessToken == "" {
+			fmt.Println(string(jsonStr))
+		} else {
+			if verbose {
+				fmt.Println("Result from token-exchange")
+				ShowJSonResponse(result, verbose)
+			}
+			accessToken = myToken.AccessToken
+		}
+	}
+	return accessToken
+}
+
+func ShowJSonResponse(result map[string]interface{}, verbose bool) {
+	fmt.Println("==========")
+	resultJson, _ := json.MarshalIndent(result, "", "    ")
+	if verbose {
+		fmt.Println("OIDC Response Body")
+	}
+	fmt.Println(string(resultJson))
+	fmt.Println("==========")
+}

--- a/token-exchange-doc.md
+++ b/token-exchange-doc.md
@@ -1,0 +1,33 @@
+# Token-Exchanges in OAuth2/OIDC
+
+The standards are 
+
+* JWT Bearer for authorization grants, e.g. [RFC7523, section 2.1](https://www.rfc-editor.org/info/rfc7523)
+* Token Exchange, a generic standard according [RFC8693](https://www.rfc-editor.org/info/rfc8693)
+
+The JWT bearer flow is mainly used to provide principal propagation for ID-Tokens from an external system and
+from one application to another.
+
+The generic token-exchange grant type is supporting more types of incoming and outgoing token types. They are
+defined with subject_token_type and requested_token_type.
+
+The API for token-exchange is documented in
+https://help.sap.com/docs/cloud-identity-services/cloud-identity-services/configure-client-to-call-identity-authentication-token-exchange
+
+New parameters combined with documentation:
+
+* assertion -> subject_token
+* subject_type -> subject_token_type ( only last part needed, access_token, id_token, refresh_token, jwt)
+* requested_type -> requested_token_type ( only last part needed, access_token, id_token, saml2)
+* provider_name -> resource parameter with provider name from https://help.sap.com/docs/cloud-identity-services/cloud-identity-services/consume-apis-from-other-applications
+
+Example:
+
+`openid-client -issuer https://<ias-host-name> -client_secret <ias-secret> -client_id <ias-client id> -requested_type saml2 -provider_name <name of API, e.g. SSO> -login_hint <user attribute>`
+
+With this call you get a browser windows opened, then
+
+1. Login (if corp.IdP is enabled, login to corp.IdP)
+2. IAS id-token created
+3. SAML Bearer token is returned
+


### PR DESCRIPTION
Add 2 new commands

* jwt-bearer
* token-exchange

JWT bearer is working with existing id_tokens and return a new id_token

Token-Exchange from RFC 8693 is used for App2App in IAS and can be used to generate a ID or SAML token based on a token.

The API for token-exchange is documented in
https://help.sap.com/docs/cloud-identity-services/cloud-identity-services/configure-client-to-call-identity-authentication-token-exchange

New parameters combined with Docu:
* assertion -> subject_token
* subject_type -> subject_token_type  ( only last part needed, access_token, id_token, refresh_token, jwt)
* requested_type -> requested_token_type ( only last part needed, access_token, id_token, saml2)
* provider_name -> resource parameter with provider name from https://help.sap.com/docs/cloud-identity-services/cloud-identity-services/consume-apis-from-other-applications

Example:

`openid-client -issuer https://<ias-host-name> -client_secret <ias-secret> -client_id <ias-client id> -requested_type saml2 -provider_name <name of API, e.g. SSO> -login_hint <user attribute>`

With this call you get a browser windows opended, then 
1. login (if corp.IdP is enable, login to corp.IdP)
2. IAS id-token created
3. SAML Bearer token is returned