### PR TITLE
Introspect

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,9 @@ Command: (authorization_code is default)
        token-exchange     Perform OAuth2 Token Exchange (RFC 8693).
        jwt-bearer         Perform OAuth2 JWT Bearer Grant Type.
        saml-bearer        Perform OAuth2 SAML 2.0 Bearer Grant Type.
-       passcode           Retrieve user passcode from X509 user authentication.
+       passcode           Retrieve user passcode from X509 user authentication. Need user_tls for user authentication.
+       idp_token          Retrieve trusted IdP token. Need assertion for user trust and client authentication.
+       introspect         Perform OAuth2 Introspection Endpoint Call. Need token input parameter.
        version            Show version.
        help               Show this help for more details.
 
@@ -64,7 +66,9 @@ Flags:
       -refresh          Bool flag. Default false. If true, call refresh flow for the received id_token.
       -idp_token        Bool flag. Default false. If true, call the OIDC IdP token exchange endpoint (IAS specific only) and return the response.
       -idp_scope        OIDC scope parameter. Default no scope is set. If you set the parameter idp_scope, it is set in IdP token exchange endpoint (IAS specific only).
+      -introspect       Bool flag. Default false. If true, call the OIDC token introspect endpoint (if provided in well-known) and return the response.
       -refresh_expiry   Value in seconds. Optional parameter to reduce Refresh Token Lifetime.
+      -token            Input token for token introspect and token-exchange calls.
       -token_format     Format for access_token. Possible values are opaque and jwt. Optional parameter, default: opaque
       -app_tid          Optional parameter for IAS multi-tenant applications.
       -cmd              Single command to be executed. Supported commands currently: jwks, client_credentials, password

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -286,6 +286,7 @@ func HandleRefreshFlow(clientID string, appTid string, clientSecret string, exis
 	client := &http.Client{
 		Transport: &http.Transport{
 			TLSClientConfig: &tls.Config{
+				Renegotiation:      tls.RenegotiateOnceAsClient,
 				InsecureSkipVerify: skipTlsVerification,
 			},
 		},

--- a/pkg/client/exchange.go
+++ b/pkg/client/exchange.go
@@ -213,3 +213,35 @@ func HandlePasscode(issuer string, tlsClient http.Client, verbose bool) string {
 	}
 	return passcode
 }
+
+func HandleTokenIntrospect(request url.Values, token string, tokenEndpoint string, tlsClient http.Client, verbose bool) string {
+	request.Set("token", token)
+	req, requestError := http.NewRequest("POST", tokenEndpoint, strings.NewReader(request.Encode()))
+	if requestError != nil {
+		log.Fatal(requestError)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+	req.Header.Set("User-Agent", agent)
+	resp, clientError := tlsClient.Do(req)
+	if clientError != nil {
+		log.Fatal(clientError)
+	}
+	var result map[string]interface{}
+	var resultString string
+	json.NewDecoder(resp.Body).Decode(&result)
+	if result != nil {
+		jsonStr, marshalError := json.MarshalIndent(result, "", "    ")
+		if marshalError != nil {
+			log.Fatal(marshalError)
+		}
+		resultString = string(jsonStr)
+		if verbose {
+			fmt.Println("Response from token introspect endpoint ")
+			ShowJSonResponse(result, verbose)
+		} else {
+			fmt.Println(resultString)
+		}
+	}
+	return resultString
+}


### PR DESCRIPTION
Added introspect in 2 variants.

a) after a token request, e.g. authorization code flow, same client session
b) extra command call - introspect

a) option -introspect and -token added
b) command introspect and option -token added


Examples
a )

`openid-client -issuer https://mytenant.accounts400.ondemand.com -client_id b9f2ac13-e1a9-44fd-ba09-b9ce950dd30e -client_tls ./ias-retrieved-key.p12 -pin changeit -introspect`

b)

`openid-client introspect -issuer https://mytenant.accounts400.ondemand.com -client_id b9f2ac13-e1a9-44fd-ba09-b9ce950dd30e -client_tls ./ias-retrieved-key.p12 -pin changeit -token <retrieved token>`

